### PR TITLE
Implement agents, knowledge management, and board context wiring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,10 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "mammoth": "^1.8.0",
         "monday-sdk-js": "^0.5.6",
+        "multer": "^1.4.5-lts.1",
+        "pdf-parse": "^1.1.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -3079,6 +3082,15 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
+      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
@@ -3269,6 +3281,12 @@
       "engines": {
         "node": ">= 6.0.0"
       }
+    },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
     },
     "node_modules/archiver": {
       "version": "5.3.2",
@@ -3841,6 +3859,12 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
@@ -4155,8 +4179,18 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -4735,6 +4769,57 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/concat-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/concat-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/concurrently": {
       "version": "9.2.1",
       "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
@@ -4858,7 +4943,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -5268,6 +5352,12 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/dingbat-to-unicode": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
+      "integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -5320,6 +5410,15 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/duck": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/duck/-/duck-0.1.12.tgz",
+      "integrity": "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==",
+      "license": "BSD",
+      "dependencies": {
+        "underscore": "^1.13.1"
       }
     },
     "node_modules/dunder-proto": {
@@ -7235,6 +7334,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -9081,6 +9186,54 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -9223,6 +9376,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lilconfig": {
@@ -9700,6 +9862,17 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lop": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/lop/-/lop-0.4.2.tgz",
+      "integrity": "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "duck": "^0.1.12",
+        "option": "~0.2.1",
+        "underscore": "^1.13.1"
+      }
+    },
     "node_modules/lowercase-keys": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
@@ -9760,6 +9933,39 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/mammoth": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/mammoth/-/mammoth-1.11.0.tgz",
+      "integrity": "sha512-BcEqqY/BOwIcI1iR5tqyVlqc3KIaMRa4egSoK83YAVrBf6+yqdAAbtUcFDCWX8Zef8/fgNZ6rl4VUv+vVX8ddQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.6",
+        "argparse": "~1.0.3",
+        "base64-js": "^1.5.1",
+        "bluebird": "~3.4.0",
+        "dingbat-to-unicode": "^1.0.1",
+        "jszip": "^3.7.1",
+        "lop": "^0.4.2",
+        "path-is-absolute": "^1.0.0",
+        "underscore": "^1.13.1",
+        "xmlbuilder": "^10.0.0"
+      },
+      "bin": {
+        "mammoth": "bin/mammoth"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/mammoth/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/math-intrinsics": {
@@ -9910,6 +10116,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/monday-sdk-js": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/monday-sdk-js/-/monday-sdk-js-0.5.6.tgz",
@@ -9924,6 +10142,25 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "1.4.5-lts.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.2.tgz",
+      "integrity": "sha512-VzGiVigcG9zUAoCNU+xShztrlr1auZOlurXynNvO9GiWD1/mTBbUljOKY+qMeazBqXgRnjzeEgJI/wyjJUHg9A==",
+      "deprecated": "Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
     },
     "node_modules/mute-stream": {
       "version": "0.0.8",
@@ -9992,6 +10229,12 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
       "license": "MIT"
     },
     "node_modules/node-fetch": {
@@ -10341,6 +10584,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/option": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/option/-/option-0.2.4.tgz",
+      "integrity": "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -10494,6 +10743,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -10638,7 +10893,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10675,6 +10929,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pdf-parse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
+      "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.1.0",
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/picocolors": {
@@ -11017,7 +11293,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/process-warning": {
@@ -12031,6 +12306,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -12283,7 +12564,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/stack-utils": {
@@ -12346,6 +12626,14 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
       "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
       "license": "MIT"
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -12984,6 +13272,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -13032,6 +13326,12 @@
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/underscore": {
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
       "license": "MIT"
     },
     "node_modules/undici-types": {
@@ -13502,6 +13802,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
+      "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,10 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "mammoth": "^1.8.0",
     "monday-sdk-js": "^0.5.6",
+    "multer": "^1.4.5-lts.1",
+    "pdf-parse": "^1.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/src/client/components/ChatView.jsx
+++ b/src/client/components/ChatView.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import '../styles/ChatView.css';
 import '../styles/components.css';
 
-function ChatView({ boardId, settings, onSelectAgent, onOpenSettings }) {
+function ChatView({ boardId, boardSchema, settings, onSelectAgent, onOpenSettings }) {
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState('');
   const [isSending, setIsSending] = useState(false);
@@ -57,7 +57,8 @@ function ChatView({ boardId, settings, onSelectAgent, onOpenSettings }) {
         body: JSON.stringify({
           boardId,
           message: trimmed,
-          agentId: activeAgent.id
+          agentId: activeAgent.id,
+          boardSchema: boardSchema || ''
         })
       });
 
@@ -105,7 +106,7 @@ function ChatView({ boardId, settings, onSelectAgent, onOpenSettings }) {
         <div>
           <div className="chat-agent-name">{activeAgent?.name || 'Assistant'}</div>
           <div className="chat-agent-meta">
-            model: {settings?.defaultModel || 'claude-sonnet-4.5'} • temp:{' '}
+            model: {settings?.defaultModel || 'claude-sonnet-4.7'} • temp:{' '}
             {(activeAgent?.temperature ?? 0.3).toFixed(1)}
           </div>
         </div>

--- a/src/client/components/SettingsModal.jsx
+++ b/src/client/components/SettingsModal.jsx
@@ -1,40 +1,138 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 
-export default function SettingsModal({ open, onClose, initial, onSave }) {
+const DEFAULT_MODEL = 'claude-sonnet-4.7';
+const DEFAULT_AGENT = {
+  id: 'bid-assistant',
+  name: 'Bid Assistant',
+  system: 'You parse construction bid docs and extract key fields...',
+  temperature: 0.3,
+  knowledgeFileIds: []
+};
+
+const sanitizeAgents = (agents) => {
+  const source = Array.isArray(agents) && agents.length ? agents : [DEFAULT_AGENT];
+  return source.map((agent, index) => {
+    const temperature = Number(agent?.temperature);
+    return {
+      id: agent?.id || (index === 0 ? DEFAULT_AGENT.id : `agent-${index + 1}`),
+      name: agent?.name || (index === 0 ? DEFAULT_AGENT.name : `Agent ${index + 1}`),
+      system: agent?.system || '',
+      temperature: Number.isFinite(temperature) ? temperature : DEFAULT_AGENT.temperature,
+      knowledgeFileIds: Array.isArray(agent?.knowledgeFileIds) ? agent.knowledgeFileIds : []
+    };
+  });
+};
+
+export default function SettingsModal({ open, boardId, onClose, initial, onSave }) {
   const [poeKey, setPoeKey] = useState(initial?.poeKey || '');
-  const [defaultModel, setDefaultModel] = useState(initial?.defaultModel || 'claude-sonnet-4.5');
-  const [selectedAgentId, setSelectedAgentId] = useState(initial?.selectedAgentId || 'bid-assistant');
-  const [agents, setAgents] = useState(
-    initial?.agents || [
-      {
-        id: 'bid-assistant',
-        name: 'Bid Assistant',
-        system: 'You parse construction bid docs and extract key fields...',
-        temperature: 0.3
-      }
-    ]
+  const [defaultModel, setDefaultModel] = useState(initial?.defaultModel || DEFAULT_MODEL);
+  const [selectedAgentId, setSelectedAgentId] = useState(
+    initial?.selectedAgentId || DEFAULT_AGENT.id
   );
+  const [agents, setAgents] = useState(() => sanitizeAgents(initial?.agents));
+
+  const [knowledgeFiles, setKnowledgeFiles] = useState([]);
+  const [isKnowledgeLoading, setIsKnowledgeLoading] = useState(false);
+  const [knowledgeError, setKnowledgeError] = useState(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const fileInputRef = useRef(null);
+
+  const boardQuery = useMemo(() => (boardId ? `?boardId=${boardId}` : ''), [boardId]);
 
   useEffect(() => {
     if (!open) return;
     setPoeKey(initial?.poeKey || '');
-    setDefaultModel(initial?.defaultModel || 'claude-sonnet-4.5');
+    setDefaultModel(initial?.defaultModel || DEFAULT_MODEL);
+    const sanitizedAgents = sanitizeAgents(initial?.agents);
+    setAgents(sanitizedAgents);
     setSelectedAgentId(
-      initial?.selectedAgentId || initial?.agents?.[0]?.id || 'bid-assistant'
-    );
-    setAgents(
-      initial?.agents?.length
-        ? initial.agents
-        : [
-            {
-              id: 'bid-assistant',
-              name: 'Bid Assistant',
-              system: 'You parse construction bid docs and extract key fields...',
-              temperature: 0.3
-            }
-          ]
+      initial?.selectedAgentId || sanitizedAgents[0]?.id || DEFAULT_AGENT.id
     );
   }, [open, initial]);
+
+  const fetchKnowledge = async () => {
+    try {
+      setIsKnowledgeLoading(true);
+      setKnowledgeError(null);
+      const res = await fetch(`/api/poe/knowledge${boardQuery}`);
+      if (!res.ok) throw new Error(`Failed to load knowledge (${res.status})`);
+      const data = await res.json();
+      const files = Array.isArray(data?.files) ? data.files : [];
+      setKnowledgeFiles(files);
+      setAgents((prev) =>
+        prev.map((agent) => ({
+          ...agent,
+          knowledgeFileIds: (agent.knowledgeFileIds || []).filter((id) =>
+            files.some((file) => file.id === id)
+          )
+        }))
+      );
+    } catch (err) {
+      console.error('Failed to fetch knowledge', err);
+      setKnowledgeError(err.message);
+    } finally {
+      setIsKnowledgeLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    fetchKnowledge();
+  }, [open, boardQuery]);
+
+  const handleUploadClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = async (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    try {
+      setIsUploading(true);
+      setKnowledgeError(null);
+      const formData = new FormData();
+      formData.append('file', file);
+      if (boardId) {
+        formData.append('boardId', boardId);
+      }
+      const res = await fetch(`/api/poe/knowledge/upload${boardQuery}`, {
+        method: 'POST',
+        body: formData
+      });
+      if (!res.ok) {
+        const detail = await res.json().catch(() => ({}));
+        throw new Error(detail?.error || `Upload failed (${res.status})`);
+      }
+      await fetchKnowledge();
+    } catch (err) {
+      console.error('Knowledge upload failed', err);
+      setKnowledgeError(err.message);
+    } finally {
+      setIsUploading(false);
+      if (event.target) {
+        event.target.value = '';
+      }
+    }
+  };
+
+  const handleDeleteKnowledge = async (fileId) => {
+    try {
+      const res = await fetch(`/api/poe/knowledge/${fileId}${boardQuery}`, {
+        method: 'DELETE'
+      });
+      if (!res.ok) throw new Error(`Failed to delete file (${res.status})`);
+      setKnowledgeFiles((prev) => prev.filter((file) => file.id !== fileId));
+      setAgents((prev) =>
+        prev.map((agent) => ({
+          ...agent,
+          knowledgeFileIds: (agent.knowledgeFileIds || []).filter((id) => id !== fileId)
+        }))
+      );
+    } catch (err) {
+      console.error('Delete knowledge failed', err);
+      setKnowledgeError(err.message);
+    }
+  };
 
   if (!open) return null;
 
@@ -42,7 +140,7 @@ export default function SettingsModal({ open, onClose, initial, onSave }) {
     const id = `agent-${Math.random().toString(36).slice(2, 8)}`;
     setAgents((prev) => [
       ...prev,
-      { id, name: 'New Agent', system: '', temperature: 0.2 }
+      { id, name: 'New Agent', system: '', temperature: 0.2, knowledgeFileIds: [] }
     ]);
   };
 
@@ -57,10 +155,27 @@ export default function SettingsModal({ open, onClose, initial, onSave }) {
     }
   };
 
+  const handleKnowledgeSelect = (agentId, event) => {
+    const selected = Array.from(event.target.selectedOptions).map((option) => option.value);
+    updateAgent(agentId, { knowledgeFileIds: selected });
+  };
+
   const handleSave = () => {
-    const filteredAgents = agents.filter((agent) => agent.id && agent.name);
+    const filteredAgents = agents
+      .filter((agent) => agent.id && agent.name)
+      .map((agent) => ({
+        ...agent,
+        temperature: Number.isFinite(Number(agent.temperature))
+          ? Number(agent.temperature)
+          : DEFAULT_AGENT.temperature,
+        knowledgeFileIds: Array.from(
+          new Set((agent.knowledgeFileIds || []).filter((id) => id && typeof id === 'string'))
+        )
+      }));
+
     const effectiveSelected =
       filteredAgents.find((agent) => agent.id === selectedAgentId)?.id || filteredAgents[0]?.id || '';
+
     onSave({
       poeKey,
       defaultModel,
@@ -73,6 +188,7 @@ export default function SettingsModal({ open, onClose, initial, onSave }) {
     <div style={S.backdrop} onClick={onClose}>
       <div style={S.modal} onClick={(event) => event.stopPropagation()}>
         <h3>Settings</h3>
+
         <div style={S.row}>
           <label>POE API Key</label>
           <input
@@ -83,6 +199,7 @@ export default function SettingsModal({ open, onClose, initial, onSave }) {
             style={S.input}
           />
         </div>
+
         <div style={S.row}>
           <label>Default Model</label>
           <select
@@ -90,11 +207,13 @@ export default function SettingsModal({ open, onClose, initial, onSave }) {
             onChange={(event) => setDefaultModel(event.target.value)}
             style={S.input}
           >
-            <option value="claude-sonnet-4.5">Claude-Sonnet-4.5</option>
+            <option value="claude-sonnet-4.7">Claude-Sonnet-4.7</option>
+            <option value="claude-haiku-4.1">Claude-Haiku-4.1</option>
             <option value="gpt-5">GPT-5</option>
             <option value="gemini-2.5-pro">Gemini-2.5-Pro</option>
           </select>
         </div>
+
         <div style={S.row}>
           <label>Active Agent</label>
           <select
@@ -110,66 +229,103 @@ export default function SettingsModal({ open, onClose, initial, onSave }) {
           </select>
         </div>
 
-        <div style={{ margin: '12px 0' }}>
-          <button onClick={addAgent} style={S.secondary} type="button">
-            + Add Agent
-          </button>
-          <div
-            style={{
-              marginTop: 8,
-              maxHeight: 240,
-              overflow: 'auto',
-              border: '1px solid #eee',
-              borderRadius: 8,
-              padding: 8
-            }}
-          >
-            {agents.map((agent) => (
-              <div
-                key={agent.id}
-                style={{ borderBottom: '1px dashed #eee', paddingBottom: 8, marginBottom: 8 }}
-              >
-                <div style={{ display: 'flex', gap: 8 }}>
-                  <input
-                    value={agent.name}
-                    onChange={(event) => updateAgent(agent.id, { name: event.target.value })}
-                    style={S.input}
-                  />
-                  <button
-                    onClick={() => removeAgent(agent.id)}
-                    style={S.danger}
-                    type="button"
-                  >
-                    Delete
-                  </button>
-                </div>
-                <textarea
-                  rows={3}
-                  placeholder="System prompt"
-                  value={agent.system}
-                  onChange={(event) => updateAgent(agent.id, { system: event.target.value })}
-                  style={{ ...S.input, resize: 'vertical' }}
+        <div style={S.sectionHeader}>Agents</div>
+        <button onClick={addAgent} style={S.secondary} type="button">
+          + Add Agent
+        </button>
+        <div style={S.agentList}>
+          {agents.map((agent) => (
+            <div key={agent.id} style={S.agentCard}>
+              <div style={S.agentHeader}>
+                <input
+                  value={agent.name}
+                  onChange={(event) => updateAgent(agent.id, { name: event.target.value })}
+                  style={S.input}
                 />
-                <div>
-                  <label>Temperature</label>
-                  <input
-                    type="number"
-                    min={0}
-                    max={1}
-                    step={0.1}
-                    value={agent.temperature}
-                    onChange={(event) =>
-                      updateAgent(agent.id, { temperature: Number(event.target.value) })
-                    }
-                    style={{ ...S.input, width: 120 }}
-                  />
-                </div>
+                <button onClick={() => removeAgent(agent.id)} style={S.danger} type="button">
+                  Delete
+                </button>
               </div>
-            ))}
-          </div>
+              <textarea
+                rows={3}
+                placeholder="System prompt"
+                value={agent.system}
+                onChange={(event) => updateAgent(agent.id, { system: event.target.value })}
+                style={{ ...S.input, resize: 'vertical' }}
+              />
+              <div style={S.inlineRow}>
+                <label>Temperature</label>
+                <input
+                  type="number"
+                  min={0}
+                  max={1}
+                  step={0.1}
+                  value={agent.temperature}
+                  onChange={(event) =>
+                    updateAgent(agent.id, { temperature: Number(event.target.value) })
+                  }
+                  style={{ ...S.input, width: 120 }}
+                />
+              </div>
+              <div style={S.inlineRow}>
+                <label>Knowledge</label>
+                <select
+                  multiple
+                  value={agent.knowledgeFileIds}
+                  onChange={(event) => handleKnowledgeSelect(agent.id, event)}
+                  style={{ ...S.input, height: 96 }}
+                >
+                  {knowledgeFiles.map((file) => (
+                    <option key={file.id} value={file.id}>
+                      {file.title} ({file.chunks} chunks)
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          ))}
         </div>
 
-        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+        <div style={S.sectionHeader}>Knowledge Base</div>
+        <div style={S.inlineRow}>
+          <button onClick={handleUploadClick} style={S.secondary} type="button" disabled={isUploading}>
+            {isUploading ? 'Uploading…' : 'Upload Knowledge'}
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".pdf,.doc,.docx,.txt,.csv,.json"
+            style={{ display: 'none' }}
+            onChange={handleFileChange}
+          />
+          {isKnowledgeLoading && <span style={S.infoText}>Loading…</span>}
+          {knowledgeError && <span style={S.errorText}>{knowledgeError}</span>}
+        </div>
+
+        <div style={S.knowledgeList}>
+          {!knowledgeFiles.length && !isKnowledgeLoading && (
+            <div style={S.empty}>No knowledge uploaded yet.</div>
+          )}
+          {knowledgeFiles.map((file) => (
+            <div key={file.id} style={S.knowledgeItem}>
+              <div>
+                <div style={S.knowledgeTitle}>{file.title}</div>
+                <div style={S.knowledgeMeta}>
+                  {(file.size / 1024).toFixed(1)} KB • {file.chunks} chunks • {file.type}
+                </div>
+              </div>
+              <button
+                onClick={() => handleDeleteKnowledge(file.id)}
+                style={S.danger}
+                type="button"
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+        </div>
+
+        <div style={S.footer}>
           <button onClick={onClose} style={S.secondary} type="button">
             Cancel
           </button>
@@ -195,9 +351,11 @@ const S = {
   modal: {
     background: '#fff',
     borderRadius: 12,
-    width: 720,
+    width: 780,
     maxWidth: '92vw',
-    padding: 16,
+    padding: 20,
+    maxHeight: '92vh',
+    overflowY: 'auto',
     boxShadow: '0 12px 40px rgba(0,0,0,.2)'
   },
   row: {
@@ -233,5 +391,84 @@ const S = {
     padding: '6px 10px',
     borderRadius: 8,
     cursor: 'pointer'
+  },
+  errorText: {
+    color: '#b91c1c',
+    fontSize: 13
+  },
+  infoText: {
+    color: '#64748b',
+    fontSize: 13
+  },
+  sectionHeader: {
+    marginTop: 18,
+    marginBottom: 8,
+    fontSize: 15,
+    fontWeight: 600
+  },
+  agentList: {
+    marginTop: 8,
+    maxHeight: 260,
+    overflow: 'auto',
+    border: '1px solid #eee',
+    borderRadius: 8,
+    padding: 8,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 12
+  },
+  agentCard: {
+    borderBottom: '1px dashed #eee',
+    paddingBottom: 8,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 8
+  },
+  agentHeader: {
+    display: 'flex',
+    gap: 8
+  },
+  inlineRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 12
+  },
+  knowledgeList: {
+    marginTop: 8,
+    border: '1px solid #eee',
+    borderRadius: 8,
+    padding: 8,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 8,
+    maxHeight: 220,
+    overflowY: 'auto'
+  },
+  knowledgeItem: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: 12,
+    paddingBottom: 6,
+    borderBottom: '1px dashed #f1f5f9'
+  },
+  knowledgeTitle: {
+    fontWeight: 600,
+    fontSize: 14
+  },
+  knowledgeMeta: {
+    fontSize: 12,
+    color: '#64748b'
+  },
+  empty: {
+    fontSize: 13,
+    color: '#6b7280'
+  },
+  footer: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    gap: 8,
+    marginTop: 16
   }
 };
+

--- a/src/server/routes/poe.js
+++ b/src/server/routes/poe.js
@@ -1,14 +1,30 @@
 const express = require('express');
+const multer = require('multer');
+
 const router = express.Router();
 
 // ===== DEV STORAGE (replace with Monday storage later) =====
-const SETTINGS_BY_BOARD = new Map(); // boardId -> { poeKey, defaultModel, selectedAgentId, agents: [...] }
+// Per-board settings and knowledge.
+const SETTINGS_BY_BOARD = new Map(); // boardId -> Settings
+const KNOWLEDGE_BY_BOARD = new Map(); // boardId -> { files: [{id, title, type, size, chunks:[{id, text}]}] }
 const ACTION_LOG = new Map(); // boardId -> [{ ts, type, itemId, note }]
+
+/**
+ * Settings shape:
+ * {
+ *   poeKey: string,
+ *   defaultModel: string,           // default 'claude-sonnet-4.7'
+ *   selectedAgentId: string,
+ *   agents: [{ id, name, system, temperature, knowledgeFileIds: string[] }]
+ * }
+ */
 
 // helpers
 const getBoardId = (req) => String(req.body?.boardId || req.query?.boardId || 'global');
 const getSettings = (boardId) => SETTINGS_BY_BOARD.get(boardId) || null;
-const setSettings = (boardId, settings) => SETTINGS_BY_BOARD.set(boardId, settings);
+const setSettings = (boardId, s) => SETTINGS_BY_BOARD.set(boardId, s);
+const getKnowledge = (boardId) => KNOWLEDGE_BY_BOARD.get(boardId) || { files: [] };
+const setKnowledge = (boardId, k) => KNOWLEDGE_BY_BOARD.set(boardId, k);
 const logAction = (boardId, entry) => {
   const arr = ACTION_LOG.get(boardId) || [];
   arr.unshift({ ts: new Date().toISOString(), ...entry });
@@ -25,37 +41,172 @@ router.post('/settings', (req, res) => {
   const { settings } = req.body || {};
   if (!settings) return res.status(400).json({ error: 'Missing settings' });
 
+  const agents = Array.isArray(settings.agents)
+    ? settings.agents.map((agent) => ({
+        ...agent,
+        knowledgeFileIds: Array.isArray(agent?.knowledgeFileIds) ? agent.knowledgeFileIds : []
+      }))
+    : [];
+
   const next = {
     poeKey: settings.poeKey || '',
-    defaultModel: settings.defaultModel || 'claude-sonnet-4.5',
-    selectedAgentId: settings.selectedAgentId || 'bid-assistant',
-    agents: Array.isArray(settings.agents) ? settings.agents : []
+    defaultModel: settings.defaultModel || 'claude-sonnet-4.7',
+    selectedAgentId:
+      settings.selectedAgentId || agents[0]?.id || (settings.agents?.[0]?.id || 'bid-assistant'),
+    agents
   };
   setSettings(boardId, next);
   res.json({ ok: true });
 });
 
+// ===== KNOWLEDGE MANAGEMENT =====
+const upload = multer({ limits: { fileSize: 10 * 1024 * 1024 } }); // 10MB
+
+async function fileToText(file) {
+  if (file.mimetype === 'application/pdf') {
+    const pdfParseModule = await import('pdf-parse');
+    const pdfParse = pdfParseModule.default || pdfParseModule;
+    const data = await pdfParse(file.buffer);
+    return data.text || '';
+  }
+  if (file.mimetype === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document') {
+    const mammothModule = await import('mammoth');
+    const mammoth = mammothModule.default || mammothModule;
+    const result = await mammoth.extractRawText({ buffer: file.buffer });
+    return result.value || '';
+  }
+  return file.buffer.toString('utf8');
+}
+
+function chunkText(str, chunkSize = 1200) {
+  const chunks = [];
+  if (!str) return chunks;
+  let i = 0;
+  while (i < str.length) {
+    const slice = str.slice(i, i + chunkSize);
+    if (slice.trim()) {
+      chunks.push({ id: `c_${i}`, text: slice });
+    }
+    i += chunkSize;
+  }
+  return chunks;
+}
+
+router.post('/knowledge/upload', upload.single('file'), async (req, res) => {
+  try {
+    const boardId = getBoardId(req);
+    if (!req.file) return res.status(400).json({ error: 'Missing file' });
+    const text = await fileToText(req.file);
+    const chunks = chunkText(text);
+
+    const kb = getKnowledge(boardId);
+    const fileId = `k_${Date.now()}`;
+    kb.files.unshift({
+      id: fileId,
+      title: req.file.originalname,
+      type: req.file.mimetype,
+      size: req.file.size,
+      chunks
+    });
+    setKnowledge(boardId, kb);
+
+    res.json({ ok: true, fileId, chunks: chunks.length });
+  } catch (e) {
+    res.status(500).json({ error: 'Parse failed', detail: e?.message });
+  }
+});
+
+router.get('/knowledge', (req, res) => {
+  const kb = getKnowledge(getBoardId(req));
+  res.json({
+    files: kb.files.map((f) => ({
+      id: f.id,
+      title: f.title,
+      type: f.type,
+      size: f.size,
+      chunks: f.chunks.length
+    }))
+  });
+});
+
+router.delete('/knowledge/:id', (req, res) => {
+  const boardId = getBoardId(req);
+  const kb = getKnowledge(boardId);
+  const next = { files: kb.files.filter((f) => f.id !== req.params.id) };
+  setKnowledge(boardId, next);
+  res.json({ ok: true });
+});
+
 // ===== CHAT =====
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function topKChunks(kbFiles, query, k = 6) {
+  if (!query) return [];
+  const tokens = String(query)
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((token) => escapeRegExp(token));
+  if (!tokens.length) return [];
+  const matcher = new RegExp(tokens.join('|'), 'g');
+  const scored = [];
+  for (const file of kbFiles) {
+    for (const chunk of file.chunks) {
+      const matches = chunk.text.toLowerCase().match(matcher);
+      const score = matches ? matches.length : 0;
+      if (score > 0) {
+        scored.push({ score, text: chunk.text });
+      }
+    }
+  }
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, k).map((s) => s.text);
+}
+
 router.post('/chat', async (req, res) => {
   try {
     const boardId = getBoardId(req);
-    const saved = getSettings(boardId) || {};
-    const poeKey = saved.poeKey || process.env.POE_API_KEY || null;
+    const settings = getSettings(boardId) || {};
+    const poeKey = settings.poeKey || process.env.POE_API_KEY || null;
     if (!poeKey) return res.status(400).json({ error: 'Missing Poe API key' });
 
-    const model = saved.defaultModel || 'claude-sonnet-4.5';
-    const agentId = req.body?.agentId || saved.selectedAgentId || 'bid-assistant';
+    const model = settings.defaultModel || 'claude-sonnet-4.7';
+    const agentId = req.body?.agentId || settings.selectedAgentId || 'bid-assistant';
     const agent =
-      (saved.agents || []).find((a) => a.id === agentId) ||
-      { name: 'Bid Assistant', system: 'You parse bid docs…', temperature: 0.3 };
+      (settings.agents || []).find((a) => a.id === agentId) ||
+      {
+        name: 'Bid Assistant',
+        system: 'You parse construction bid docs and extract key fields.',
+        temperature: 0.3,
+        knowledgeFileIds: []
+      };
 
-    const userMessage = String(req.body?.message || '').trim();
+    const { message, boardSchema } = req.body || {};
+    const userMessage = String(message || '').trim();
     if (!userMessage) return res.status(400).json({ error: 'Missing message' });
 
-    // TODO: Call Poe with poeKey/model/agent/system/temperature + userMessage.
-    const reply = `[${agent.name}] (model=${model}, temp=${agent.temperature}) → ${userMessage}`;
+    const kb = getKnowledge(boardId);
+    const attachedFiles = (agent.knowledgeFileIds || [])
+      .map((id) => kb.files.find((f) => f.id === id))
+      .filter(Boolean);
+    const contextChunks = topKChunks(attachedFiles, userMessage, 6);
 
-    // Optional: log create/update actions for dashboard
+    const system = [
+      agent.system || '',
+      boardSchema ? `\nBoard context:\n${boardSchema}` : '',
+      contextChunks.length
+        ? `\nRelevant knowledge:\n${contextChunks
+            .map((text, idx) => `[K${idx + 1}] ${text}`)
+            .join('\n\n')}`
+        : ''
+    ].join('');
+
+    // TODO: Call Poe with: { model, system, temperature: agent.temperature, user: message }
+    // For now return the composed prompt to verify:
+    const reply = `(${agent.name}) Using model=${model}. System length=${system.length}. User="${userMessage}"`;
+
     if (req.body?.createdItemId) {
       logAction(boardId, {
         type: 'create',
@@ -64,9 +215,9 @@ router.post('/chat', async (req, res) => {
       });
     }
 
-    res.json({ ok: true, reply });
+    return res.json({ ok: true, debug: { model, usedChunks: contextChunks.length }, reply });
   } catch (e) {
-    console.error('Poe chat error:', e);
+    console.error('chat error:', e);
     res.status(500).json({ error: 'Internal error', detail: e.message });
   }
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,7 +9,20 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 3000,
-    strictPort: true
+    strictPort: true,
+    allowedHosts: (() => {
+      const hosts = ['localhost', '127.0.0.1'];
+      if (process.env.FRONTEND_TUNNEL_HOST) {
+        hosts.push(process.env.FRONTEND_TUNNEL_HOST);
+      }
+      return hosts;
+    })(),
+    proxy: {
+      '/api': {
+        target: 'http://localhost:4000',
+        changeOrigin: true
+      }
+    }
   },
   preview: {
     port: 3000,


### PR DESCRIPTION
## Summary
- add per-board in-memory settings and knowledge storage with upload, list, and delete endpoints
- include agent knowledge, board schema, and selected model when composing chat requests
- extend the settings UI to manage agents, default model selection, and knowledge file attachments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e06ea2b4dc832faa3a43ab136558a9