### PR TITLE
Update Poe model catalog and defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,12 +153,19 @@ The AI intelligently searches for keywords like:
 
 | Model | Provider | Best For |
 |-------|----------|----------|
-| **Claude-Sonnet-4.5** ⭐ | Anthropic | Document parsing & extraction |
+| **Claude-Sonnet-4.5** ⭐ | Anthropic | Balanced default for documents |
+| Claude-Opus-4.1 | Anthropic | Highest quality Claude responses |
+| Claude-Sonnet-3.5 | Anthropic | Reliable general-purpose chats |
+| Claude-Haiku-3.5 | Anthropic | Rapid lightweight replies |
+| Claude-Opus-4-Reasoning | Anthropic | Extended reasoning chains |
+| Claude-Sonnet-4-Reasoning | Anthropic | Reasoning-focused Sonnet |
 | GPT-5 | OpenAI | Advanced reasoning |
 | GPT-5-Mini | OpenAI | Fast responses |
+| GPT-5-Nano | OpenAI | Cost-efficient automation |
+| GPT-G-Codex | OpenAI | Code and technical tasks |
 | Gemini-2.5-Pro | Google | Multimodal analysis |
-| Claude-Opus-4 | Anthropic | Complex reasoning |
-| Llama-3.3-70B | Meta | Open-source |
+| Gemini-2.5-Flash | Google | Low-latency production flows |
+| Gemini-2.5-Flash-Lite | Google | Budget-friendly latency |
 
 ### Custom Instructions Example
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -11,6 +11,7 @@ Routes rely on Monday's built-in authentication via `req.mondayContext`. Ensure 
 ### GET `/api/poe/models`
 
 Returns the list of available Poe models and identifies the default model.
+The list currently includes Claude Sonnet/Opus variants (including reasoning modes), GPT-5 family models, GPT-G-Codex, and the Gemini 2.5 lineup.
 
 **Response**
 ```json
@@ -19,7 +20,7 @@ Returns the list of available Poe models and identifies the default model.
     {
       "name": "Claude-Sonnet-4.5",
       "provider": "Anthropic",
-      "description": "Best for document parsing and structured data extraction",
+      "description": "Balanced default for high-quality chats and document parsing",
       "maxTokens": 8192,
       "supportsVision": true,
       "supportsFunctions": true,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,14 +17,21 @@ The settings panel is divided into multiple sections:
 
 ## 2. AI Model Configuration
 
-Select which Poe model the assistant should use by default. The dropdown lists all supported models as of October 2025:
+Select which Poe model the assistant should use by default. The dropdown lists all supported models as of March 2026:
 
 - `Claude-Sonnet-4.5` (default and recommended)
+- `Claude-Opus-4.1`
+- `Claude-Sonnet-3.5`
+- `Claude-Haiku-3.5`
+- `Claude-Opus-4-Reasoning`
+- `Claude-Sonnet-4-Reasoning`
 - `GPT-5`
 - `GPT-5-Mini`
+- `GPT-5-Nano`
+- `GPT-G-Codex`
 - `Gemini-2.5-Pro`
-- `Claude-Opus-4`
-- `Llama-3.3-70B`
+- `Gemini-2.5-Flash`
+- `Gemini-2.5-Flash-Lite`
 
 The selection is stored in Monday storage under the `app_settings` key and used by both chat and file parsing endpoints.
 

--- a/src/client/App.jsx
+++ b/src/client/App.jsx
@@ -19,7 +19,7 @@ const normalizeSettings = (incoming) => {
   const selected = agents.find((agent) => agent.id === base.selectedAgentId)?.id || agents[0].id;
   return {
     poeKey: base.poeKey || '',
-    defaultModel: base.defaultModel || 'claude-sonnet-4.5',
+    defaultModel: base.defaultModel || 'Claude-Sonnet-4.5',
     selectedAgentId: selected,
     agents
   };

--- a/src/client/components/ChatView.jsx
+++ b/src/client/components/ChatView.jsx
@@ -105,7 +105,7 @@ function ChatView({ boardId, settings, onSelectAgent, onOpenSettings }) {
         <div>
           <div className="chat-agent-name">{activeAgent?.name || 'Assistant'}</div>
           <div className="chat-agent-meta">
-            model: {settings?.defaultModel || 'claude-sonnet-4.5'} • temp:{' '}
+            model: {settings?.defaultModel || 'Claude-Sonnet-4.5'} • temp:{' '}
             {(activeAgent?.temperature ?? 0.3).toFixed(1)}
           </div>
         </div>

--- a/src/client/components/ModelPicker.jsx
+++ b/src/client/components/ModelPicker.jsx
@@ -4,39 +4,81 @@ const MODELS = [
   {
     name: 'Claude-Sonnet-4.5',
     provider: 'Anthropic',
-    description: 'Best for document parsing',
+    description: 'Balanced default for high-quality chats',
     icon: '🔷',
     recommended: true
   },
   {
+    name: 'Claude-Opus-4.1',
+    provider: 'Anthropic',
+    description: 'Most capable Claude model available',
+    icon: '🔷'
+  },
+  {
+    name: 'Claude-Sonnet-3.5',
+    provider: 'Anthropic',
+    description: 'Reliable general-purpose assistant',
+    icon: '🔷'
+  },
+  {
+    name: 'Claude-Haiku-3.5',
+    provider: 'Anthropic',
+    description: 'Fast lightweight option for quick tasks',
+    icon: '🔷'
+  },
+  {
+    name: 'Claude-Opus-4-Reasoning',
+    provider: 'Anthropic',
+    description: 'Enhanced reasoning-focused Claude',
+    icon: '🧠'
+  },
+  {
+    name: 'Claude-Sonnet-4-Reasoning',
+    provider: 'Anthropic',
+    description: 'Reasoning-tuned Sonnet variant',
+    icon: '🧠'
+  },
+  {
     name: 'GPT-5',
     provider: 'OpenAI',
-    description: 'Advanced reasoning',
+    description: 'Advanced flagship GPT model',
     icon: '🟢'
   },
   {
     name: 'GPT-5-Mini',
     provider: 'OpenAI',
-    description: 'Fast and efficient',
+    description: 'Faster GPT-5 with lower cost',
     icon: '🟢'
+  },
+  {
+    name: 'GPT-5-Nano',
+    provider: 'OpenAI',
+    description: 'Ultra-efficient GPT-5 variant',
+    icon: '🟢'
+  },
+  {
+    name: 'GPT-G-Codex',
+    provider: 'OpenAI',
+    description: 'Optimized for code generation',
+    icon: '💻'
   },
   {
     name: 'Gemini-2.5-Pro',
     provider: 'Google',
-    description: 'Multimodal analysis',
+    description: 'Premium multimodal Gemini model',
     icon: '🔶'
   },
   {
-    name: 'Claude-Opus-4',
-    provider: 'Anthropic',
-    description: 'Most capable reasoning',
-    icon: '🔷'
+    name: 'Gemini-2.5-Flash',
+    provider: 'Google',
+    description: 'Speed-focused Gemini for production',
+    icon: '⚡'
   },
   {
-    name: 'Llama-3.3-70B',
-    provider: 'Meta',
-    description: 'Open-source alternative',
-    icon: '🦙'
+    name: 'Gemini-2.5-Flash-Lite',
+    provider: 'Google',
+    description: 'Cost-efficient Gemini flash tier',
+    icon: '⚡'
   }
 ];
 

--- a/src/client/components/SettingsModal.jsx
+++ b/src/client/components/SettingsModal.jsx
@@ -1,8 +1,24 @@
 import React, { useEffect, useState } from 'react';
 
+const MODEL_OPTIONS = [
+  'Claude-Sonnet-4.5',
+  'Claude-Opus-4.1',
+  'Claude-Sonnet-3.5',
+  'Claude-Haiku-3.5',
+  'Claude-Opus-4-Reasoning',
+  'Claude-Sonnet-4-Reasoning',
+  'GPT-5',
+  'GPT-5-Mini',
+  'GPT-5-Nano',
+  'GPT-G-Codex',
+  'Gemini-2.5-Pro',
+  'Gemini-2.5-Flash',
+  'Gemini-2.5-Flash-Lite'
+];
+
 export default function SettingsModal({ open, onClose, initial, onSave }) {
   const [poeKey, setPoeKey] = useState(initial?.poeKey || '');
-  const [defaultModel, setDefaultModel] = useState(initial?.defaultModel || 'claude-sonnet-4.5');
+  const [defaultModel, setDefaultModel] = useState(initial?.defaultModel || 'Claude-Sonnet-4.5');
   const [selectedAgentId, setSelectedAgentId] = useState(initial?.selectedAgentId || 'bid-assistant');
   const [agents, setAgents] = useState(
     initial?.agents || [
@@ -18,7 +34,7 @@ export default function SettingsModal({ open, onClose, initial, onSave }) {
   useEffect(() => {
     if (!open) return;
     setPoeKey(initial?.poeKey || '');
-    setDefaultModel(initial?.defaultModel || 'claude-sonnet-4.5');
+    setDefaultModel(initial?.defaultModel || 'Claude-Sonnet-4.5');
     setSelectedAgentId(
       initial?.selectedAgentId || initial?.agents?.[0]?.id || 'bid-assistant'
     );
@@ -90,9 +106,11 @@ export default function SettingsModal({ open, onClose, initial, onSave }) {
             onChange={(event) => setDefaultModel(event.target.value)}
             style={S.input}
           >
-            <option value="claude-sonnet-4.5">Claude-Sonnet-4.5</option>
-            <option value="gpt-5">GPT-5</option>
-            <option value="gemini-2.5-pro">Gemini-2.5-Pro</option>
+            {MODEL_OPTIONS.map((model) => (
+              <option key={model} value={model}>
+                {model}
+              </option>
+            ))}
           </select>
         </div>
         <div style={S.row}>

--- a/src/client/components/SettingsView.jsx
+++ b/src/client/components/SettingsView.jsx
@@ -57,9 +57,12 @@ function SettingsView({ settings, onSave, boardData }) {
         <div className="help-box">
           <strong>💡 Model Recommendations:</strong>
           <ul>
-            <li><strong>Claude-Sonnet-4.5:</strong> Best for document parsing and data extraction</li>
-            <li><strong>GPT-5:</strong> Advanced reasoning for complex tasks</li>
-            <li><strong>Gemini-2.5-Pro:</strong> Excellent multimodal understanding</li>
+            <li><strong>Claude-Sonnet-4.5:</strong> Balanced default for high-quality chats</li>
+            <li><strong>Claude-Opus-4.1:</strong> Highest quality Claude responses</li>
+            <li><strong>Claude-Sonnet-4-Reasoning:</strong> Use for tough reasoning chains</li>
+            <li><strong>GPT-5 / GPT-5-Mini / GPT-5-Nano:</strong> Choose based on desired speed vs. power</li>
+            <li><strong>GPT-G-Codex:</strong> Optimized for code generation tasks</li>
+            <li><strong>Gemini-2.5-Pro / Flash / Flash-Lite:</strong> Great for multimodal or latency-sensitive work</li>
           </ul>
         </div>
       </section>

--- a/src/server/config/models.js
+++ b/src/server/config/models.js
@@ -1,18 +1,58 @@
-// Poe API Model Definitions (October 2025)
+// Poe API Model Definitions (updated March 2026)
 const POE_MODELS = {
   'Claude-Sonnet-4.5': {
     name: 'Claude-Sonnet-4.5',
     provider: 'Anthropic',
-    description: 'Best for document parsing and structured data extraction',
+    description: 'Balanced default for high-quality chats and document parsing',
     maxTokens: 8192,
     supportsVision: true,
     supportsFunctions: true,
     default: true
   },
+  'Claude-Opus-4.1': {
+    name: 'Claude-Opus-4.1',
+    provider: 'Anthropic',
+    description: 'Highest capability Claude model for demanding workflows',
+    maxTokens: 8192,
+    supportsVision: true,
+    supportsFunctions: true
+  },
+  'Claude-Sonnet-3.5': {
+    name: 'Claude-Sonnet-3.5',
+    provider: 'Anthropic',
+    description: 'Reliable mid-tier assistant with strong instruction following',
+    maxTokens: 8192,
+    supportsVision: true,
+    supportsFunctions: true
+  },
+  'Claude-Haiku-3.5': {
+    name: 'Claude-Haiku-3.5',
+    provider: 'Anthropic',
+    description: 'Fast lightweight Claude suited for quick responses',
+    maxTokens: 4096,
+    supportsVision: true,
+    supportsFunctions: true
+  },
+  'Claude-Opus-4-Reasoning': {
+    name: 'Claude-Opus-4-Reasoning',
+    provider: 'Anthropic',
+    description: 'Enhanced reasoning-focused variant of Opus',
+    maxTokens: 8192,
+    supportsVision: true,
+    supportsFunctions: true
+  },
+  'Claude-Sonnet-4-Reasoning': {
+    name: 'Claude-Sonnet-4-Reasoning',
+    provider: 'Anthropic',
+    description: 'Reasoning-tuned Sonnet model for complex problem solving',
+    maxTokens: 8192,
+    supportsVision: true,
+    supportsFunctions: true
+  },
   'GPT-5': {
     name: 'GPT-5',
     provider: 'OpenAI',
-    description: 'Advanced reasoning and complex task completion',
+    description: 'Advanced flagship GPT for nuanced reasoning and creation',
     maxTokens: 8192,
     supportsVision: true,
     supportsFunctions: true
@@ -20,33 +60,49 @@ const POE_MODELS = {
   'GPT-5-Mini': {
     name: 'GPT-5-Mini',
     provider: 'OpenAI',
-    description: 'Fast and efficient for simple tasks',
+    description: 'Faster GPT-5 variant balancing quality and latency',
+    maxTokens: 8192,
+    supportsVision: true,
+    supportsFunctions: true
+  },
+  'GPT-5-Nano': {
+    name: 'GPT-5-Nano',
+    provider: 'OpenAI',
+    description: 'Cost-efficient GPT-5 tuned for lightweight tasks',
     maxTokens: 4096,
+    supportsVision: false,
+    supportsFunctions: true
+  },
+  'GPT-G-Codex': {
+    name: 'GPT-G-Codex',
+    provider: 'OpenAI',
+    description: 'Specialized GPT for code understanding and generation',
+    maxTokens: 8192,
     supportsVision: false,
     supportsFunctions: true
   },
   'Gemini-2.5-Pro': {
     name: 'Gemini-2.5-Pro',
     provider: 'Google',
-    description: 'Excellent for multimodal analysis',
+    description: 'Premium multimodal Gemini for rich content understanding',
     maxTokens: 8192,
     supportsVision: true,
     supportsFunctions: true
   },
-  'Claude-Opus-4': {
-    name: 'Claude-Opus-4',
-    provider: 'Anthropic',
-    description: 'Most capable model for complex reasoning',
+  'Gemini-2.5-Flash': {
+    name: 'Gemini-2.5-Flash',
+    provider: 'Google',
+    description: 'Latency-optimized Gemini with multimodal support',
     maxTokens: 4096,
     supportsVision: true,
     supportsFunctions: true
   },
-  'Llama-3.3-70B': {
-    name: 'Llama-3.3-70B',
-    provider: 'Meta',
-    description: 'Open-source alternative',
+  'Gemini-2.5-Flash-Lite': {
+    name: 'Gemini-2.5-Flash-Lite',
+    provider: 'Google',
+    description: 'Cost-effective Gemini for rapid responses',
     maxTokens: 4096,
-    supportsVision: false,
+    supportsVision: true,
     supportsFunctions: true
   }
 };

--- a/src/server/routes/poe.js
+++ b/src/server/routes/poe.js
@@ -27,7 +27,7 @@ router.post('/settings', (req, res) => {
 
   const next = {
     poeKey: settings.poeKey || '',
-    defaultModel: settings.defaultModel || 'claude-sonnet-4.5',
+    defaultModel: settings.defaultModel || 'Claude-Sonnet-4.5',
     selectedAgentId: settings.selectedAgentId || 'bid-assistant',
     agents: Array.isArray(settings.agents) ? settings.agents : []
   };
@@ -43,7 +43,7 @@ router.post('/chat', async (req, res) => {
     const poeKey = saved.poeKey || process.env.POE_API_KEY || null;
     if (!poeKey) return res.status(400).json({ error: 'Missing Poe API key' });
 
-    const model = saved.defaultModel || 'claude-sonnet-4.5';
+    const model = saved.defaultModel || 'Claude-Sonnet-4.5';
     const agentId = req.body?.agentId || saved.selectedAgentId || 'bid-assistant';
     const agent =
       (saved.agents || []).find((a) => a.id === agentId) ||


### PR DESCRIPTION
## Summary
- set Claude-Sonnet-4.5 as the canonical default selection and expand the model picker with the latest Poe options
- align settings persistence, server-side model definitions, and helper messaging with the updated catalog
- refresh documentation and README tables to reflect the new lineup and guidance

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e07784a938832fb2692e11bc676db7