### PR TITLE
Add production server entrypoint for Monday Code hosting

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Your Name",
   "license": "MIT",
   "scripts": {
-    "start": "npm run dev",
+    "start": "node src/server/prodServer.js",
     "dev": "concurrently \"npm run dev:client\" \"npm run dev:server\"",
     "dev:client": "vite --config vite.config.js",
     "dev:server": "cross-env NODE_ENV=development nodemon --config nodemon.json",

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,50 +1,27 @@
 require('dotenv').config();
-const { createServer } = require('@mondaycom/apps-sdk');
 const express = require('express');
 const cors = require('cors');
 
-// Initialize Monday server
-const server = createServer({
-  logLevel: process.env.LOG_LEVEL || 'info'
-});
+const server = express();
 
-// Middleware
 server.use(cors());
 server.use(express.json({ limit: '50mb' }));
 server.use(express.urlencoded({ extended: true, limit: '50mb' }));
-
-// Ensure mondayContext exists (dev/tunnel mode has no signature)
 server.use((req, _res, next) => {
   if (!req.mondayContext) req.mondayContext = {};
   next();
 });
 
-// Import routes
-const poeRoutes = require('./routes/poe');
-const boardRoutes = require('./routes/board');
+server.use('/api/poe', require('./routes/poe'));
+server.use('/api/board', require('./routes/board'));
 
-// Mount routes
-server.use('/api/poe', poeRoutes);
-server.use('/api/board', boardRoutes);
-
-// Health check
-server.get('/health', (req, res) => {
-  res.json({ 
-    status: 'ok', 
-    timestamp: new Date().toISOString(),
-    version: '1.1.0'
-  });
+server.get('/health', (_req, res) => {
+  res.json({ status: 'ok', t: Date.now() });
 });
 
-// Error handling
-server.use((error, req, res, next) => {
-  void next;
-  console.error('Server error:', error);
-  res.status(500).json({
-    error: 'Internal server error',
-    message: error.message,
-    ...(process.env.NODE_ENV === 'development' && { stack: error.stack })
-  });
+server.use((err, _req, res, _next) => {
+  console.error('Server error:', err);
+  res.status(500).json({ error: 'Internal server error', message: err?.message });
 });
 
 module.exports = server;

--- a/src/server/prodServer.js
+++ b/src/server/prodServer.js
@@ -1,0 +1,7 @@
+const server = require('./index');
+const PORT = process.env.PORT || 8080;
+
+server.set?.('trust proxy', 1);
+server.listen(PORT, '0.0.0.0', () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add a production server bootstrap that binds the Express app on port 8080 for Monday Code
- simplify the server creation to a plain Express instance exported from index.js
- point npm start to the production server entry point to satisfy Monday Code deployment expectations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e19f2b8398832f8b76208ce51d4142