### PR TITLE
Fix Vite base path for Monday CDN

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,7 @@ import { resolve } from 'path';
 const rootDir = resolve(__dirname, 'src', 'client');
 
 export default defineConfig({
+  base: '',
   root: rootDir,
   plugins: [react()],
   server: {


### PR DESCRIPTION
## Summary
- add Vite base configuration so assets load correctly from Monday's CDN sub-path

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e1a77d6018832f990e6c6523376054